### PR TITLE
Add comparison with `nlopt` to example.ipynb.

### DIFF
--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -26,7 +26,8 @@
     "from scipy.special import expit\n",
     "import time\n",
     "\n",
-    "import statsmodels.api as sm"
+    "import statsmodels.api as sm\n",
+    "import nlopt"
    ]
   },
   {
@@ -95,7 +96,9 @@
     "    objective = np.sum(residuals**2)\n",
     "    grad = 2 * X.T @ residuals\n",
     "    gradient[:] = grad.flatten()\n",
-    "    return objective"
+    "    return objective\n",
+    "\n",
+    "linear_start = np.random.rand(k)"
    ]
   },
   {
@@ -112,8 +115,8 @@
       " 0.64700696 0.70195589 0.26487498 0.77280983 0.78267599 0.36787315\n",
       " 0.72791074 0.06571446 0.72615144 0.38766298 0.03820425 0.39468909\n",
       " 0.04304362 0.72195013]\n",
-      "CPU times: user 5.47 s, sys: 151 ms, total: 5.62 s\n",
-      "Wall time: 371 ms\n"
+      "CPU times: user 1.15 s, sys: 2.45 s, total: 3.6 s\n",
+      "Wall time: 675 ms\n"
      ]
     }
    ],
@@ -122,9 +125,44 @@
     "optimizer = pyensmallen.L_BFGS()\n",
     "result_linear_ens = optimizer.optimize(\n",
     "    lambda params, gradient: linear_objective(params, gradient, X_linear, y_linear),\n",
-    "    np.random.rand(k),\n",
+    "    linear_start,\n",
     ")\n",
     "print(result_linear_ens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3580699f",
+   "metadata": {},
+   "source": [
+    "### nlopt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b3261db1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.51556024 0.94691468 0.23404849 0.55121759 0.97818756 0.24338623\n",
+      " 0.64700696 0.70195589 0.26487498 0.77280983 0.78267599 0.36787315\n",
+      " 0.72791074 0.06571446 0.72615144 0.38766298 0.03820425 0.39468909\n",
+      " 0.04304362 0.72195013]\n",
+      "CPU times: user 2.05 s, sys: 4.45 s, total: 6.5 s\n",
+      "Wall time: 1.12 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "opt = nlopt.opt(nlopt.LD_LBFGS, k)\n",
+    "opt.set_min_objective(lambda params, gradient: linear_objective(params, gradient, X_linear, y_linear))\n",
+    "result_linear_nlopt = opt.optimize(linear_start)\n",
+    "print(result_linear_nlopt)"
    ]
   },
   {
@@ -137,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "e1318ad5",
    "metadata": {},
    "outputs": [
@@ -149,8 +187,8 @@
       " 0.64700696 0.70195589 0.26487498 0.77280983 0.78267599 0.36787315\n",
       " 0.72791074 0.06571446 0.72615144 0.38766298 0.03820425 0.39468909\n",
       " 0.04304362 0.72195013]\n",
-      "CPU times: user 1min 30s, sys: 2.62 s, total: 1min 32s\n",
-      "Wall time: 6.03 s\n"
+      "CPU times: user 20.9 s, sys: 34 s, total: 55 s\n",
+      "Wall time: 10 s\n"
      ]
     }
    ],
@@ -158,7 +196,7 @@
     "%%time\n",
     "result_linear_scipy = scipy.optimize.minimize(\n",
     "    fun=lambda b: np.sum((X_linear @ b - y_linear) ** 2),\n",
-    "    x0=np.random.rand(k),\n",
+    "    x0=linear_start,\n",
     "    jac=lambda b: 2 * X_linear.T @ (X_linear @ b - y_linear),\n",
     ").x\n",
     "print(result_linear_scipy)"
@@ -174,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "16b477c4",
    "metadata": {},
    "outputs": [
@@ -186,8 +224,8 @@
       " 0.64700696 0.70195589 0.26487498 0.77280983 0.78267599 0.36787315\n",
       " 0.72791074 0.06571446 0.72615144 0.38766298 0.03820425 0.39468909\n",
       " 0.04304362 0.72195013]\n",
-      "CPU times: user 23.1 s, sys: 3.6 s, total: 26.7 s\n",
-      "Wall time: 24.9 s\n"
+      "CPU times: user 47.9 s, sys: 2.86 s, total: 50.8 s\n",
+      "Wall time: 50.4 s\n"
      ]
     }
    ],
@@ -210,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "1bd523d6",
    "metadata": {},
    "outputs": [
@@ -218,41 +256,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.76 s, sys: 11 ms, total: 2.77 s\n",
-      "Wall time: 411 ms\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([0.51556024, 0.94691468, 0.23404849, 0.55121759, 0.97818756,\n",
-       "       0.24338623, 0.64700696, 0.70195589, 0.26487498, 0.77280983,\n",
-       "       0.78267599, 0.36787315, 0.72791074, 0.06571446, 0.72615144,\n",
-       "       0.38766298, 0.03820425, 0.39468909, 0.04304362, 0.72195013])"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "np.linalg.lstsq(X_linear, y_linear, rcond=None)[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "43383527",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 7.65 s, sys: 339 ms, total: 7.99 s\n",
-      "Wall time: 1.63 s\n"
+      "CPU times: user 1.62 s, sys: 1.05 s, total: 2.67 s\n",
+      "Wall time: 798 ms\n"
      ]
     },
     {
@@ -265,6 +270,39 @@
       ]
      },
      "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "np.linalg.lstsq(X_linear, y_linear, rcond=None)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "43383527",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 7.05 s, sys: 3.25 s, total: 10.3 s\n",
+      "Wall time: 3.51 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([0.51556024, 0.94691468, 0.23404849, 0.55121759, 0.97818756,\n",
+       "       0.24338623, 0.64700696, 0.70195589, 0.26487498, 0.77280983,\n",
+       "       0.78267599, 0.36787315, 0.72791074, 0.06571446, 0.72615144,\n",
+       "       0.38766298, 0.03820425, 0.39468909, 0.04304362, 0.72195013])"
+      ]
+     },
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -284,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "3d5449a7",
    "metadata": {},
    "outputs": [
@@ -292,10 +330,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.17265046 0.1778864  0.49767087 0.64843282 0.98414584 0.21942117\n",
-      " 0.53109792 0.68926063 0.9222397  0.90592967 0.08626337 0.45876915\n",
-      " 0.07621689 0.47511573 0.2636066  0.66777898 0.76603666 0.01132669\n",
-      " 0.01504104 0.02569576]\n"
+      "[0.74560931 0.96037048 0.30659196 0.78557459 0.04726211 0.89027718\n",
+      " 0.24117347 0.89673488 0.36550133 0.97993472 0.25816369 0.58473241\n",
+      " 0.38081169 0.95958797 0.92324205 0.08471913 0.33333406 0.5071405\n",
+      " 0.20493563 0.33786489]\n"
      ]
     }
    ],
@@ -318,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "b8446939",
    "metadata": {},
    "outputs": [],
@@ -327,14 +365,18 @@
     "    z = X @ params\n",
     "    h = expit(z)\n",
     "    objective = -np.sum(y * np.log(h) + (1 - y) * np.log1p(-h))\n",
+    "    if np.isnan(objective):\n",
+    "        objective = np.inf\n",
     "    grad = X.T @ (h - y)\n",
     "    gradient[:] = grad\n",
-    "    return objective"
+    "    return objective\n",
+    "\n",
+    "logistic_start = np.random.rand(k)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "add9a17e",
    "metadata": {},
    "outputs": [
@@ -342,12 +384,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.17934344  0.17613996  0.47516449  0.65546909  0.99649103  0.18322668\n",
-      "  0.49237341  0.73499685  0.92133107  0.92753401  0.05997722  0.45651545\n",
-      "  0.08532323  0.49863473  0.30227163  0.63633992  0.77514856  0.04266289\n",
-      " -0.03735041  0.03002617]\n",
-      "CPU times: user 66.6 ms, sys: 144 μs, total: 66.8 ms\n",
-      "Wall time: 10.2 ms\n"
+      "[0.78103852 0.8975452  0.32361818 0.75455507 0.06058863 0.87528454\n",
+      " 0.21365507 0.90129849 0.40673921 0.97992142 0.30068721 0.50152611\n",
+      " 0.40801893 0.97259116 0.93292288 0.11679675 0.31657035 0.53056071\n",
+      " 0.22217501 0.36503279]\n",
+      "CPU times: user 26.2 ms, sys: 129 ms, total: 155 ms\n",
+      "Wall time: 27.8 ms\n"
      ]
     }
    ],
@@ -363,9 +405,58 @@
     "    lambda params, gradient: logistic_objective(\n",
     "        params, gradient, X_logistic2, y_logistic2\n",
     "    ),\n",
-    "    np.random.rand(k),\n",
+    "    logistic_start,\n",
     ")\n",
     "print(result_logistic_ens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "004027cd",
+   "metadata": {},
+   "source": [
+    "### nlopt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "fdc7e066",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.78103852 0.8975452  0.32361818 0.75455507 0.06058863 0.87528454\n",
+      " 0.21365507 0.90129849 0.40673921 0.97992142 0.30068721 0.50152611\n",
+      " 0.40801892 0.97259117 0.93292288 0.11679676 0.31657035 0.53056071\n",
+      " 0.22217501 0.36503279]\n",
+      "CPU times: user 54.5 ms, sys: 184 ms, total: 239 ms\n",
+      "Wall time: 36.8 ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_202269/510062118.py:4: RuntimeWarning: divide by zero encountered in log\n",
+      "  objective = -np.sum(y * np.log(h) + (1 - y) * np.log1p(-h))\n",
+      "/tmp/ipykernel_202269/510062118.py:4: RuntimeWarning: invalid value encountered in multiply\n",
+      "  objective = -np.sum(y * np.log(h) + (1 - y) * np.log1p(-h))\n",
+      "/tmp/ipykernel_202269/510062118.py:4: RuntimeWarning: divide by zero encountered in log1p\n",
+      "  objective = -np.sum(y * np.log(h) + (1 - y) * np.log1p(-h))\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "opt = nlopt.opt(nlopt.LD_LBFGS, k)\n",
+    "opt.set_min_objective(lambda params, gradient: logistic_objective(\n",
+    "        params, gradient, X_logistic2, y_logistic2\n",
+    "    ))\n",
+    "result_logistic_nlopt = opt.optimize(logistic_start)\n",
+    "print(result_logistic_nlopt)"
    ]
   },
   {
@@ -378,20 +469,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "6dee0bb8",
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<timed exec>:4: RuntimeWarning: divide by zero encountered in log\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.17934344  0.17613996  0.47516449  0.65546909  0.99649103  0.18322668\n",
-      "  0.49237341  0.73499685  0.92133107  0.92753401  0.05997722  0.45651545\n",
-      "  0.08532323  0.49863473  0.30227163  0.63633992  0.77514856  0.04266289\n",
-      " -0.03735041  0.03002617]\n",
-      "CPU times: user 243 ms, sys: 4.16 ms, total: 247 ms\n",
-      "Wall time: 66.9 ms\n"
+      "[0.78103852 0.89754519 0.32361818 0.75455506 0.06058863 0.87528454\n",
+      " 0.21365506 0.90129849 0.40673921 0.97992141 0.30068721 0.50152611\n",
+      " 0.40801892 0.97259116 0.93292288 0.11679676 0.31657034 0.53056071\n",
+      " 0.22217501 0.36503279]\n",
+      "CPU times: user 581 ms, sys: 2.21 s, total: 2.79 s\n",
+      "Wall time: 549 ms\n"
      ]
     }
    ],
@@ -402,7 +500,7 @@
     "        y_logistic * np.log(expit(X_logistic @ b))\n",
     "        + (1 - y_logistic) * np.log(1 - expit(X_logistic @ b))\n",
     "    ),\n",
-    "    x0=np.random.rand(k),\n",
+    "    x0=logistic_start,\n",
     "    jac=lambda b: X_logistic.T @ (expit(X_logistic @ b) - y_logistic),\n",
     ").x\n",
     "print(result_logistic_scipy)"
@@ -418,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "d90380c7",
    "metadata": {},
    "outputs": [
@@ -426,12 +524,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.17934256  0.17613886  0.47516186  0.65546576  0.99648578  0.18322555\n",
-      "  0.4923709   0.73499296  0.92132606  0.92752899  0.05997698  0.45651312\n",
-      "  0.08532281  0.49863207  0.30227002  0.63633648  0.77514439  0.0426626\n",
-      " -0.03735022  0.0300261 ]\n",
-      "CPU times: user 1.1 s, sys: 93 μs, total: 1.1 s\n",
-      "Wall time: 1.1 s\n"
+      "[0.78103139 0.8975368  0.32361526 0.75454815 0.06058797 0.87527657\n",
+      " 0.21365308 0.90129021 0.40673545 0.97991244 0.30068428 0.50152154\n",
+      " 0.40801517 0.97258238 0.93291413 0.11679587 0.31656755 0.53055581\n",
+      " 0.22217273 0.36502933]\n",
+      "CPU times: user 3.09 s, sys: 408 ms, total: 3.5 s\n",
+      "Wall time: 3.01 s\n"
      ]
     }
    ],
@@ -459,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "9dad1419",
    "metadata": {},
    "outputs": [
@@ -468,22 +566,22 @@
      "output_type": "stream",
      "text": [
       "Optimization terminated successfully.\n",
-      "         Current function value: 0.416715\n",
+      "         Current function value: 0.379271\n",
       "         Iterations 7\n",
-      "CPU times: user 111 ms, sys: 0 ns, total: 111 ms\n",
-      "Wall time: 17.6 ms\n"
+      "CPU times: user 434 ms, sys: 739 ms, total: 1.17 s\n",
+      "Wall time: 181 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "array([ 0.17934344,  0.17613996,  0.47516449,  0.65546909,  0.99649103,\n",
-       "        0.18322668,  0.49237341,  0.73499685,  0.92133107,  0.92753401,\n",
-       "        0.05997722,  0.45651545,  0.08532323,  0.49863473,  0.30227163,\n",
-       "        0.63633992,  0.77514856,  0.04266289, -0.03735041,  0.03002617])"
+       "array([0.78103852, 0.8975452 , 0.32361818, 0.75455507, 0.06058863,\n",
+       "       0.87528454, 0.21365507, 0.90129849, 0.40673921, 0.97992142,\n",
+       "       0.30068721, 0.50152611, 0.40801892, 0.97259117, 0.93292288,\n",
+       "       0.11679676, 0.31657035, 0.53056071, 0.22217501, 0.36503279])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "f7c03a51",
    "metadata": {},
    "outputs": [
@@ -511,8 +609,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.86917029 0.96687352 0.57554146 0.2946829  0.65323721 0.74023376\n",
-      " 0.28311498 0.59695143 0.19782333 0.94529361]\n"
+      "[0.09990002 0.0547525  0.40475966 0.20774043 0.24657925 0.85989722\n",
+      " 0.86845961 0.14166248 0.09512955 0.92680615]\n"
      ]
     }
    ],
@@ -535,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "ba86a97c",
    "metadata": {},
    "outputs": [],
@@ -549,12 +647,14 @@
     "    # Compute the gradient\n",
     "    grad = X.T @ (lambda_ - y)\n",
     "    gradient[:] = grad.ravel()\n",
-    "    return objective"
+    "    return objective\n",
+    "\n",
+    "poisson_start = np.random.rand(k)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "c4c87692",
    "metadata": {},
    "outputs": [
@@ -562,10 +662,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.86877556 0.96685947 0.57539955 0.29520506 0.65312095 0.73924052\n",
-      " 0.28189688 0.59807216 0.1970171  0.94496917]\n",
-      "CPU times: user 1.89 s, sys: 4.9 ms, total: 1.89 s\n",
-      "Wall time: 129 ms\n"
+      "[0.0978387  0.05226027 0.40495176 0.20798044 0.24750742 0.85914355\n",
+      " 0.86512068 0.14383657 0.09889716 0.92837268]\n",
+      "CPU times: user 244 ms, sys: 427 ms, total: 671 ms\n",
+      "Wall time: 115 ms\n"
      ]
     }
    ],
@@ -574,9 +674,63 @@
     "optimizer = pyensmallen.L_BFGS()\n",
     "result_poisson_ens = optimizer.optimize(\n",
     "    lambda params, gradient: poisson_objective(params, gradient, X_poisson, y_poisson),\n",
-    "    np.zeros(k),\n",
+    "    poisson_start,\n",
     ")\n",
     "print(result_poisson_ens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f77071ae",
+   "metadata": {},
+   "source": [
+    "### nlopt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "ad4ac603",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_202269/4126034426.py:5: RuntimeWarning: overflow encountered in exp\n",
+      "  lambda_ = np.exp(Xbeta)\n",
+      "/tmp/ipykernel_202269/4126034426.py:6: RuntimeWarning: divide by zero encountered in log\n",
+      "  objective = np.sum(lambda_ - np.multiply(y, np.log(lambda_)))\n",
+      "/tmp/ipykernel_202269/4126034426.py:6: RuntimeWarning: invalid value encountered in multiply\n",
+      "  objective = np.sum(lambda_ - np.multiply(y, np.log(lambda_)))\n",
+      "/tmp/ipykernel_202269/4126034426.py:6: RuntimeWarning: invalid value encountered in subtract\n",
+      "  objective = np.sum(lambda_ - np.multiply(y, np.log(lambda_)))\n",
+      "/tmp/ipykernel_202269/4126034426.py:8: RuntimeWarning: invalid value encountered in matmul\n",
+      "  grad = X.T @ (lambda_ - y)\n",
+      "/tmp/ipykernel_202269/4126034426.py:8: RuntimeWarning: overflow encountered in matmul\n",
+      "  grad = X.T @ (lambda_ - y)\n"
+     ]
+    },
+    {
+     "ename": "RuntimeError",
+     "evalue": "nlopt failure",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "File \u001b[0;32m<timed exec>:4\u001b[0m\n",
+      "File \u001b[0;32m~/Repositories/netflix/xp-env/conda/envs/xp-env/lib/python3.10/site-packages/nlopt/nlopt.py:335\u001b[0m, in \u001b[0;36mopt.optimize\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m    334\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21moptimize\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39margs):\n\u001b[0;32m--> 335\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_nlopt\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mopt_optimize\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: nlopt failure"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "opt = nlopt.opt(nlopt.LD_LBFGS, k)\n",
+    "opt.set_min_objective(lambda params, gradient: poisson_objective(params, gradient, X_poisson, y_poisson))\n",
+    "opt.set_maxeval(100000)\n",
+    "result_poisson_nlopt = opt.optimize(poisson_start)\n",
+    "print(result_poisson_nlopt)"
    ]
   },
   {
@@ -589,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "4b00785b",
    "metadata": {},
    "outputs": [
@@ -597,10 +751,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.86877556 0.96685947 0.57539955 0.29520505 0.65312095 0.73924053\n",
-      " 0.28189688 0.59807215 0.1970171  0.94496917]\n",
-      "CPU times: user 5.01 s, sys: 0 ns, total: 5.01 s\n",
-      "Wall time: 347 ms\n"
+      "[0.09783871 0.05226027 0.40495176 0.20798044 0.24750742 0.85914355\n",
+      " 0.86512068 0.14383657 0.09889716 0.92837268]\n",
+      "CPU times: user 945 ms, sys: 1.79 s, total: 2.73 s\n",
+      "Wall time: 408 ms\n"
      ]
     }
    ],
@@ -608,7 +762,7 @@
     "%%time\n",
     "result_poisson_scipy = scipy.optimize.minimize(\n",
     "    fun=lambda b: np.sum(np.exp(X_poisson @ b) - y_poisson * (X_poisson @ b)),\n",
-    "    x0=np.random.rand(k),\n",
+    "    x0=poisson_start,\n",
     "    jac=lambda b: X_poisson.T @ (np.exp(X_poisson @ b) - y_poisson),\n",
     ").x\n",
     "print(result_poisson_scipy)"
@@ -656,7 +810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "e343e20d",
    "metadata": {},
    "outputs": [
@@ -664,29 +818,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Warning: Maximum number of iterations has been exceeded.\n",
-      "         Current function value: 75075747038101008.000000\n",
-      "         Iterations: 35\n",
-      "CPU times: user 6.16 s, sys: 3.54 ms, total: 6.17 s\n",
-      "Wall time: 424 ms\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/alal/miniforge3/envs/econometrics/lib/python3.12/site-packages/statsmodels/base/model.py:607: ConvergenceWarning: Maximum Likelihood optimization failed to converge. Check mle_retvals\n",
-      "  warnings.warn(\"Maximum Likelihood optimization failed to \"\n"
+      "Optimization terminated successfully.\n",
+      "         Current function value: 1.374653\n",
+      "         Iterations 27\n",
+      "CPU times: user 1.81 s, sys: 3.58 s, total: 5.39 s\n",
+      "Wall time: 838 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "array([2.52946653, 4.6910591 , 3.09004472, 0.60682215, 4.08554177,\n",
-       "       4.53577489, 0.33532728, 4.82258398, 1.23212272, 4.19929592])"
+       "array([0.09783871, 0.05226027, 0.40495176, 0.20798044, 0.24750742,\n",
+       "       0.85914355, 0.86512068, 0.14383657, 0.09889716, 0.92837268])"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -721,7 +867,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This patch updates the example.ipynb notebook with a comparison to nlopt, which is much more comparable to ensmallen performance.

To make comparisons fairer, I fixed the seed across all implementations. Generally (but not always), ensmallen does beat out the low-memory BGFS implementation in nlopt; but like ensmallen, handily beats all other optimisations demonstrated in the notebook. I have not done an exhaustive comparison, though, with the other algorithms in nlopt that may outperform BGFS.

There is also an annoying failure to converge for the Poisson regression, but I haven't looked much into that either.

However, the more I look into it, the more I like `ensmallen`... so happy to work with you on these bindings :).